### PR TITLE
Modify ug tags can be empty

### DIFF
--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -144,9 +144,7 @@ The `Model` component,
 <puml src="diagrams/StorageClassDiagram.puml" width="550" />
 
 The `Storage` component,
-* can save both global participant list data in JSON format, and read it back into corresponding objects.
-* can save event list data in JSON format, and read it back into corresponding event objects.
-* can also save participant list data of all added events in JSON format, and read them back into corresponding objects. 
+* can save global participant list data, event list data, participant list data of all added events in JSON format, and read it back into corresponding objects.
 * inherits from`AddressBookStorage` `EventBook Storage` and `UserPrefStorage`, which means it can be treated as either one (if only the functionality of only one is needed).
 * depends on some classes in the `Model` component (because the `Storage` component's job is to save/retrieve objects that belong to the `Model`)
 

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -329,7 +329,7 @@ Clears all entries from the address book.
 **Caution:**
 
 * `<KEYWORD>` name should be **alphabetic**, **non-empty** and **not longer than 64 characters**.
-* `<KEYWORD>` tag should be **alphabetic**, **non-empty** and **not longer than 64 characters**.
+* `<KEYWORD>` tag in find command should be **alphabetic**, **non-empty** and **not longer than 64 characters**.
   </box>
 
 **Examples:**

--- a/docs/diagrams/StorageClassDiagram.puml
+++ b/docs/diagrams/StorageClassDiagram.puml
@@ -1,6 +1,6 @@
 @startuml
 !include style.puml
-skinparam arrowThickness 1.1
+skinparam arrowThickness 1.0
 skinparam arrowColor STORAGE_COLOR
 skinparam classBackgroundColor STORAGE_COLOR
 
@@ -22,22 +22,36 @@ Class JsonAdaptedPerson
 Class JsonAdaptedTag
 }
 
+package "EventBook Storage" #F4F6F6{
+Class "<<interface>>\nEventBookStorage" as EventBookStorage
+Class JsonEventBookStorage
+Class JsonSerializableEventBook
+Class JsonAdaptedEvent
+}
+
 }
 
 Class HiddenOutside #FFFFFF
 HiddenOutside ..> Storage
 
 StorageManager .up.|> Storage
-StorageManager -up-> "1" UserPrefsStorage
-StorageManager -up-> "1" AddressBookStorage
+StorageManager -down-> "1" UserPrefsStorage
+StorageManager -down-> "1" AddressBookStorage
+StorageManager -down-> "1" EventBookStorage
 
-Storage -left-|> UserPrefsStorage
-Storage -right-|> AddressBookStorage
+
+Storage -down-|> UserPrefsStorage
+Storage -down-|> AddressBookStorage
+Storage -down-|> EventBookStorage
 
 JsonUserPrefsStorage .up.|> UserPrefsStorage
 JsonAddressBookStorage .up.|> AddressBookStorage
+JsonEventBookStorage .up.|> EventBookStorage
 JsonAddressBookStorage ..> JsonSerializableAddressBook
+JsonEventBookStorage ..> JsonSerializableEventBook
 JsonSerializableAddressBook --> "*" JsonAdaptedPerson
+JsonSerializableEventBook --> "*" JsonAdaptedEvent
 JsonAdaptedPerson --> "*" JsonAdaptedTag
+JsonAdaptedEvent --> "*" JsonAdaptedPerson
 
 @enduml


### PR DESCRIPTION
The tester pointed out the tag can be empty in editp command but attached an image of cautions in find command. I'm not sure whether a caution under find command can be applied to edit command. Still, I modified the caution sentence in find command to specify that "in find command" tag can't be empty.